### PR TITLE
fix(snapshot): return enum instead of printing contradictory messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,10 @@ fn main() {
         Command::Snapshot(sub) => match sub {
             SnapshotCommand::Create { name } => {
                 match snapshot::snapshot(name.as_deref()) {
-                    Ok(name) => eprintln!("Snapshot '{name}' created."),
+                    Ok(snapshot::SnapshotResult::Created(name)) =>
+                        eprintln!("Snapshot '{name}' created."),
+                    Ok(snapshot::SnapshotResult::Existed(name)) =>
+                        eprintln!("Snapshot '{name}' already exists."),
                     Err(e) => {
                         eprintln!("Snapshot failed: {e}");
                         std::process::exit(1);

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -8,9 +8,15 @@ use std::path::Path;
 use crate::consts::DEFAULT_SNAPSHOT_NAME;
 use crate::{parse, tools};
 
+/// Result of a snapshot operation.
+pub enum SnapshotResult {
+    Created(String),
+    Existed(String),
+}
+
 /// Creates a snapshot of the root subvolume at the btrfs top level.
-/// Idempotent: returns Ok if the snapshot already exists.
-pub fn snapshot(name: Option<&str>) -> Result<String, String> {
+/// Idempotent: returns Existed if the snapshot already exists.
+pub fn snapshot(name: Option<&str>) -> Result<SnapshotResult, String> {
     let name = name.unwrap_or(DEFAULT_SNAPSHOT_NAME);
     let (_, fstab) = tools::root_device()?;
     let root_subvol = tools::root_subvol_name(&fstab)?;
@@ -18,11 +24,10 @@ pub fn snapshot(name: Option<&str>) -> Result<String, String> {
     tools::with_toplevel(|toplevel| {
         let snap_path = format!("{toplevel}/{name}");
         if Path::new(&snap_path).exists() {
-            eprintln!("Snapshot '{name}' already exists; using existing protection.");
-            return Ok(name.to_string());
+            return Ok(SnapshotResult::Existed(name.to_string()));
         }
         tools::btrfs_subvol_snapshot(&format!("{toplevel}/{}", root_subvol.as_str()), &snap_path)?;
-        Ok(name.to_string())
+        Ok(SnapshotResult::Created(name.to_string()))
     })
 }
 


### PR DESCRIPTION
snapshot() returned Ok(String) for both created and already-existed cases. The function printed "already exists" internally, then the caller printed "created" for any Ok. Two contradictory messages on every idempotent call.

snapshot() now returns SnapshotResult::Created or ::Existed and prints nothing. The caller matches on the variant.

Tested on Fedora 43 aarch64 VM: all four paths (new/existing x default/named) produce exactly one correct message.