### PR TITLE
feat(snapshot): RPM plugin for universal pre-transaction snapshots

### DIFF
--- a/atomic-rollback.spec
+++ b/atomic-rollback.spec
@@ -11,6 +11,7 @@ Source1:        %{name}-%{version}-vendor.tar.gz
 BuildRequires:  cargo
 BuildRequires:  rust >= 1.85
 BuildRequires:  gcc
+BuildRequires:  rpm-devel
 
 # Runtime: the tools our code delegates to
 Requires:       btrfs-progs
@@ -35,6 +36,7 @@ cp cargo-config.toml .cargo/config.toml
 
 %build
 cargo build --release --offline
+gcc -shared -fPIC -o atomic_rollback.so plugins/atomic_rollback.c $(pkg-config --cflags --libs rpm)
 
 %check
 cargo test --release --offline
@@ -43,6 +45,8 @@ cargo test --release --offline
 install -Dm755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
 install -Dm755 hooks/90-%{name}.install %{buildroot}%{_prefix}/lib/kernel/install.d/90-%{name}.install
 install -Dm644 plugins/%{name}.actions %{buildroot}%{_sysconfdir}/dnf/libdnf5-plugins/actions.d/%{name}.actions
+install -Dm755 atomic_rollback.so %{buildroot}%{__plugindir}/atomic_rollback.so
+install -Dm644 plugins/macros.transaction_atomic_rollback %{buildroot}/usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
 
 %files
 %license LICENSE
@@ -50,5 +54,7 @@ install -Dm644 plugins/%{name}.actions %{buildroot}%{_sysconfdir}/dnf/libdnf5-pl
 %{_bindir}/%{name}
 %{_prefix}/lib/kernel/install.d/90-%{name}.install
 %config(noreplace) %{_sysconfdir}/dnf/libdnf5-plugins/actions.d/%{name}.actions
+%{__plugindir}/atomic_rollback.so
+/usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
 
 %changelog

--- a/plugins/atomic_rollback.c
+++ b/plugins/atomic_rollback.c
@@ -1,0 +1,27 @@
+#include <rpm/rpmlog.h>
+#include <rpm/rpmts.h>
+#include <rpm/rpmplugin.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define BINARY "/usr/bin/atomic-rollback"
+
+static rpmRC atomic_rollback_tsm_pre(rpmPlugin plugin, rpmts ts)
+{
+    if (rpmtsFlags(ts) & (RPMTRANS_FLAG_TEST|RPMTRANS_FLAG_BUILD_PROBS))
+        return RPMRC_OK;
+
+    if (access(BINARY, X_OK) != 0)
+        return RPMRC_OK;
+
+    int rc = system(BINARY " snapshot");
+    if (rc != 0) {
+        rpmlog(RPMLOG_ERR, "atomic-rollback: snapshot failed, aborting transaction\n");
+        return RPMRC_FAIL;
+    }
+    return RPMRC_OK;
+}
+
+struct rpmPluginHooks_s atomic_rollback_hooks = {
+    .tsm_pre = atomic_rollback_tsm_pre,
+};

--- a/plugins/macros.transaction_atomic_rollback
+++ b/plugins/macros.transaction_atomic_rollback
@@ -1,0 +1,1 @@
+%__transaction_atomic_rollback  %{__plugindir}/atomic_rollback.so

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,7 @@ fn main() {
                         eprintln!("Snapshot '{name}' created."),
                     Ok(snapshot::SnapshotResult::Existed(name)) =>
                         eprintln!("Snapshot '{name}' already exists."),
+                    Ok(snapshot::SnapshotResult::NotBtrfs) => {}
                     Err(e) => {
                         eprintln!("Snapshot failed: {e}");
                         std::process::exit(1);

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -12,14 +12,19 @@ use crate::{parse, tools};
 pub enum SnapshotResult {
     Created(String),
     Existed(String),
+    NotBtrfs,
 }
 
 /// Creates a snapshot of the root subvolume at the btrfs top level.
 /// Idempotent: returns Existed if the snapshot already exists.
+/// Returns NotBtrfs if the root filesystem is not btrfs (nothing to protect).
 pub fn snapshot(name: Option<&str>) -> Result<SnapshotResult, String> {
     let name = name.unwrap_or(DEFAULT_SNAPSHOT_NAME);
     let (_, fstab) = tools::root_device()?;
-    let root_subvol = tools::root_subvol_name(&fstab)?;
+    let root_subvol = match tools::root_subvol_name(&fstab) {
+        Ok(s) => s,
+        Err(_) => return Ok(SnapshotResult::NotBtrfs),
+    };
 
     tools::with_toplevel(|toplevel| {
         let snap_path = format!("{toplevel}/{name}");


### PR DESCRIPTION
The libdnf5 actions plugin only fires for dnf5 transactions. On Fedora 43, PackageKit (Discover, GNOME Software) uses the DNF4 backend which bypasses libdnf5. Bare `rpm -i` also bypasses it.

An RPM `tsm_pre` plugin fires synchronously before every RPM transaction regardless of frontend. Verified from source: PackageKit -> libdnf -> `dnf_transaction_commit` -> `rpmtsRun` -> `tsm_pre` plugins.

Also adds `SnapshotResult::NotBtrfs` so the snapshot command is a no-op on non-btrfs systems (exit 0, no transaction blocked).

Tested on Fedora 43 aarch64 VM:
- Plugin loads and fires for `rpm -i`
- `RPMRC_FAIL` aborts transaction cleanly
- `access()` guard skips when binary missing
- End-to-end: bare `rpm -i` triggers snapshot creation