### PR TITLE
chore: bump to 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to atomic-rollback are documented here.
 
+## [0.3.7] - 2026-04-05
+
+### Added
+
+- RPM plugin: snapshots are now created before every RPM transaction regardless of frontend (dnf, PackageKit/Discover, bare rpm). Previously only dnf5 transactions triggered snapshots via the libdnf5 actions plugin.
+
+### Fixed
+
+- `snapshot` no longer prints contradictory "already exists" and "created" messages on the same call. The function returns a typed result and the caller handles messaging.
+- `snapshot` is now a safe no-op on non-btrfs systems instead of failing and blocking package transactions.
+
 ## [0.3.6] - 2026-04-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "atomic-rollback"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "libc",
  "vstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomic-rollback"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 description = "Atomic system rollback for Fedora via Btrfs RENAME_EXCHANGE subvolume swap"
 license = "GPL-3.0-only"

--- a/atomic-rollback.spec
+++ b/atomic-rollback.spec
@@ -1,5 +1,5 @@
 Name:           atomic-rollback
-Version:        0.3.6
+Version:        0.3.7
 Release:        1%{?dist}
 Summary:        Atomic system rollback for Fedora via Btrfs RENAME_EXCHANGE
 


### PR DESCRIPTION
Changelog, version bump, Cargo.lock for v0.3.7 release.