### PR TITLE
chore: bump to 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to atomic-rollback are documented here.
 
+## [0.3.8] - 2026-04-07
+
+### Fixed
+
+- `check`, `setup`, and `migrate` failed at the baseline gate with "Btrfs subvolume 'root' not found" on systems with a non-default root subvolume name (e.g., the openSUSE Timeshift `@` layout). The root filesystem check hardcoded `"root"` instead of reading the `subvol=` mount option from `/etc/fstab`. Closes #15.
+
 ## [0.3.7] - 2026-04-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "atomic-rollback"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "libc",
  "vstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomic-rollback"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 description = "Atomic system rollback for Fedora via Btrfs RENAME_EXCHANGE subvolume swap"
 license = "GPL-3.0-only"

--- a/atomic-rollback.spec
+++ b/atomic-rollback.spec
@@ -1,5 +1,5 @@
 Name:           atomic-rollback
-Version:        0.3.7
+Version:        0.3.8
 Release:        1%{?dist}
 Summary:        Atomic system rollback for Fedora via Btrfs RENAME_EXCHANGE
 


### PR DESCRIPTION
Changelog, version bump, Cargo.lock for v0.3.8 release.