### PR TITLE
feat(check): show rollback scope (SAFE/RISK directories)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo atomic-rollback rollback
 sudo reboot
 ```
 
-With the dnf plugin installed, snapshots are automatic. Manual snapshots are still available for non-dnf changes: `sudo atomic-rollback snapshot create [name]`.
+Snapshots are automatic via the RPM plugin (covers dnf, rpm, and any RPM-based package manager). Manual snapshots are still available for non-RPM changes: `sudo atomic-rollback snapshot create [name]`.
 
 ## Commands
 
@@ -47,7 +47,7 @@ With the dnf plugin installed, snapshots are automatic. Manual snapshots are sti
 
 `sudo atomic-rollback migrate` full boot migration. Moves /boot from ext4 to Btrfs so kernels are included in snapshots. After rollback, the correct kernel boots automatically. Every step verifies the system remains bootable before proceeding. If any step fails, the system is unchanged.
 
-`sudo atomic-rollback snapshot` creates a snapshot of the current system state with the default name `root.pre-update`. Automatic via the dnf plugin; manual use for non-dnf changes. Idempotent: if the snapshot already exists, the command succeeds (existing protection is in place).
+`sudo atomic-rollback snapshot` creates a snapshot of the current system state with the default name `root.pre-update`. Automatic via the RPM plugin; manual use for non-RPM changes. Idempotent: if the snapshot already exists, the command succeeds (existing protection is in place).
 
 `sudo atomic-rollback snapshot create [name]` creates a snapshot with an optional name. Defaults to `root.pre-update` if no name is given.
 
@@ -79,7 +79,7 @@ A kernel-install hook is installed. When new kernels are installed via dnf, the 
 
 ## Automatic snapshots
 
-A libdnf5 actions plugin snapshots the root subvolume before every dnf transaction. If the snapshot cannot be created, dnf aborts. If a snapshot already exists, dnf proceeds with the existing protection. The plugin is installed automatically by the RPM.
+An RPM plugin snapshots the root subvolume before every RPM transaction (dnf, rpm, PackageKit, or any other RPM-based frontend). If the snapshot cannot be created, the transaction aborts. If a snapshot already exists, the transaction proceeds with the existing protection.
 
 ## Guarantees
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Snapshots are automatic via the RPM plugin (covers dnf, rpm, and any RPM-based p
 
 `sudo atomic-rollback snapshot list` shows available snapshots with btrfs subvolume ID, name, and creation time. Sorted by ID (chronological). System subvolumes (root, home, var) are excluded.
 
-`sudo atomic-rollback snapshot delete <name>` deletes a snapshot. Refuses subvolumes referenced by fstab (system subvolumes). Mounted and default subvolume protection is provided by the kernel and btrfs-progs.
+`sudo atomic-rollback snapshot delete <id|name>` deletes a snapshot by btrfs subvolume ID (numeric) or name. Refuses subvolumes referenced by fstab (system subvolumes). Mounted and default subvolume protection is provided by the kernel and btrfs-progs.
 
-`sudo atomic-rollback rollback [name]` restores the system to a snapshot. Defaults to `root.pre-update`. Reboot after rollback. The previous (broken) state is preserved and can be inspected or deleted.
+`sudo atomic-rollback rollback [id|name]` restores the system to a snapshot. Accepts a btrfs subvolume ID (numeric) or name. Defaults to the most recent snapshot. Re-runnable before reboot (last swap wins). Reboot after rollback. The previous (broken) state is preserved and can be inspected or deleted.
 
 ## What the migration changes
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Snapshots are automatic via the RPM plugin (covers dnf, rpm, and any RPM-based p
 
 `sudo atomic-rollback migrate` full boot migration. Moves /boot from ext4 to Btrfs so kernels are included in snapshots. After rollback, the correct kernel boots automatically. Every step verifies the system remains bootable before proceeding. If any step fails, the system is unchanged.
 
-`sudo atomic-rollback snapshot` creates a snapshot of the current system state with the default name `root.pre-update`. Automatic via the RPM plugin; manual use for non-RPM changes. Idempotent: if the snapshot already exists, the command succeeds (existing protection is in place).
+`sudo atomic-rollback snapshot` creates a snapshot of the current system state with an auto-generated timestamped name. Automatic via the RPM plugin on every transaction; manual use for non-RPM changes.
 
-`sudo atomic-rollback snapshot create [name]` creates a snapshot with an optional name. Defaults to `root.pre-update` if no name is given.
+`sudo atomic-rollback snapshot create [name]` creates a snapshot with an optional name. If no name is given, an auto-generated timestamp is used.
 
 `sudo atomic-rollback snapshot list` shows available snapshots. System subvolumes (root, home, var) are excluded.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Snapshots are automatic via the RPM plugin (covers dnf, rpm, and any RPM-based p
 
 `sudo atomic-rollback snapshot create [name]` creates a snapshot with an optional name. If no name is given, an auto-generated timestamp is used.
 
-`sudo atomic-rollback snapshot list` shows available snapshots. System subvolumes (root, home, var) are excluded.
+`sudo atomic-rollback snapshot list` shows available snapshots with btrfs subvolume ID, name, and creation time. Sorted by ID (chronological). System subvolumes (root, home, var) are excluded.
 
 `sudo atomic-rollback snapshot delete <name>` deletes a snapshot. Refuses subvolumes referenced by fstab (system subvolumes). Mounted and default subvolume protection is provided by the kernel and btrfs-progs.
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Snapshots are automatic via the RPM plugin (covers dnf, rpm, and any RPM-based p
 
 ## Commands
 
-`sudo atomic-rollback check` verifies the system is bootable. Reports what failed, why it matters, and what to do about it.
+`sudo atomic-rollback check` verifies the boot chain is valid. Reports what failed, why it matters, and what to do about it.
 
 `sudo atomic-rollback setup` separates /var and enables root snapshots and rollback. Works on the stock Fedora partition layout. No /boot changes, no ESP modification, no GRUB Btrfs dependency. After a rollback, the user selects the correct kernel from the GRUB menu if needed.
 
-`sudo atomic-rollback migrate` full boot migration. Moves /boot from ext4 to Btrfs so kernels are included in snapshots. After rollback, the correct kernel boots automatically. Every step verifies the system remains bootable before proceeding. If any step fails, the system is unchanged.
+`sudo atomic-rollback migrate` full boot migration. Moves /boot from ext4 to Btrfs so kernels are included in snapshots. After rollback, the correct kernel boots automatically. Every step verifies the boot chain remains valid before proceeding. If any step fails, the system is unchanged.
 
 `sudo atomic-rollback snapshot` creates a snapshot of the current system state with an auto-generated timestamped name. Automatic via the RPM plugin on every transaction; manual use for non-RPM changes.
 
@@ -75,7 +75,7 @@ The /boot/grub2 directory is set to NOCOW (chattr +C) and grubenv is recreated. 
 
 save_env is stripped from grub.cfg. GRUB's Btrfs driver is read-only. save_env requires write access. Since writing is impossible, save_env is a guaranteed failure. Removing it prevents an error message on every boot.
 
-A kernel-install hook is written by `migrate` as a migration artifact. When new kernels are installed, the hook creates symlinks and ensures boot entry paths are correct. This keeps the system bootable across kernel updates. The hook persists after package removal because `migrate` owns it, not the RPM.
+A kernel-install hook is written by `migrate` as a migration artifact. When new kernels are installed, the hook creates symlinks and ensures boot entry paths are correct. This keeps the boot chain valid across kernel updates. The hook persists after package removal because `migrate` owns it, not the RPM.
 
 ## Automatic snapshots
 
@@ -83,11 +83,11 @@ An RPM plugin snapshots the root subvolume before every RPM transaction (dnf, rp
 
 ## Guarantees
 
-Every intermediate state during migration is bootable. If power is lost at any point, the system boots.
+Every intermediate state during migration has a valid boot chain. If power is lost at any point, the system boots.
 
 The migration can be interrupted and resumed. Every step is idempotent.
 
-Rollback is a single atomic operation. It either fully completes or does not happen. The snapshot is verified bootable before the swap; if verification fails, the swap is refused.
+Rollback is a single atomic operation. It either fully completes or does not happen. The snapshot's boot chain is verified before the swap; if verification fails, the swap is refused.
 
 No RENAME_EXCHANGE anywhere in the tool proceeds without prior artifact verification.
 
@@ -105,32 +105,32 @@ LUKS-encrypted /boot is not supported. GRUB can only decrypt LUKS version 1, and
 
 ## How it works
 
-The migration runs ten steps. Each step creates new state alongside the old state, verifies the system remains bootable, then atomically swaps the old and new using `renameat2(RENAME_EXCHANGE)`. This is a single kernel operation that exchanges two directory entries. Either both names swap or neither does. There is no intermediate state where the system is half-migrated.
+The migration runs ten steps. Each step creates new state alongside the old state, verifies the boot chain remains valid, then atomically swaps the old and new using `renameat2(RENAME_EXCHANGE)`. This is a single kernel operation that exchanges two directory entries. Either both names swap or neither does. There is no intermediate state where the system is half-migrated.
 
 Rollback uses the same mechanism. The root subvolume is exchanged with a snapshot in one `RENAME_EXCHANGE` call. The Btrfs default subvolume ID is updated to match. On reboot, the system boots into the snapshot.
 
-The bootability check (`atomic-rollback check`) evaluates a predicate derived from tracing the actual Fedora boot chain: UEFI firmware loads shim, shim loads GRUB, GRUB parses BLS entries, the kernel mounts root per the command line, systemd mounts filesystems per fstab. Each link in this chain has a file that must exist and be correct. The check verifies every one.
+The boot chain check (`atomic-rollback check`) evaluates a predicate derived from tracing the actual Fedora boot chain: UEFI firmware loads shim, shim loads GRUB, GRUB parses BLS entries, the kernel mounts root per the command line, systemd mounts filesystems per fstab. Each link in this chain has a file that must exist and be correct. The check verifies every one.
 
 ## Verification
 
 The state machine is formally verified using [Kani](https://github.com/model-checking/kani). The following theorems are machine-checked:
 
-1. Migration preserves bootability at every step.
-2. Rollback preserves bootability (and fails without updating the default subvolume).
+1. Migration preserves boot chain validity at every step.
+2. Rollback preserves boot chain validity (and fails without updating the default subvolume).
 3. Step ordering constraints hold.
-4. Kernel installs on a migrated system preserve bootability.
+4. Kernel installs on a migrated system preserve boot chain validity.
 5. All steps are idempotent (the migration can be interrupted and resumed).
 6. The system is correct under the GRUB Btrfs write constraint (save_env failure does not affect boot, rollback, or kernel installs).
 7. Non-atomic creation by external tools (dracut, grub2-mkconfig) is safe because the verification gate prevents the atomic swap from firing on a failed creation.
 8. Every RENAME_EXCHANGE in the tool (migration, rollback, kernel install) requires prior artifact verification. No swap proceeds without it.
 9. /var separation produces consistent config: device reference format and compression options match the root mount entry, for all valid initial configurations.
-10. Every exit point (migration, rollback, kernel hook) is both bootable AND durable. `syncfs` forces the Btrfs transaction to disk before the user reboots. Derived from kernel source: `RENAME_EXCHANGE` and `set-default` use `btrfs_end_transaction` (in-memory only), not `btrfs_commit_transaction` (on-disk).
+10. Every exit point (migration, rollback, kernel hook) has a valid boot chain AND is durable. `syncfs` forces the Btrfs transaction to disk before the user reboots. Derived from kernel source: `RENAME_EXCHANGE` and `set-default` use `btrfs_end_transaction` (in-memory only), not `btrfs_commit_transaction` (on-disk).
 11. User data is never lost. /home and /var are separate subvolumes, untouched by any swap. After rollback, the old root is preserved at the snapshot name. No operation in the tool deletes root, /home, or /var.
-12. Setup (root-only, no /boot changes) preserves bootability, is reboot-safe, and data-safe. Rollback works on the setup'd system.
+12. Setup (root-only, no /boot changes) preserves boot chain validity, is reboot-safe, and data-safe. Rollback works on the setup'd system.
 
 The proofs are parameterized over hardware configurations (Cloud VM, bare metal, device reference formats, compression options) and boot chain axioms (GRUB behavior, kernel mount resolution, Secure Boot verification, transaction atomicity). Each theorem declares which axioms it requires. Kani explores all combinations symbolically. The source is in `src/proof.rs`.
 
-The parser functions (bootability check, BLS entry parsing, mount option extraction) are formally verified inline using [Verus](https://github.com/verus-lang/verus). Every loop is proven to terminate, every array access is proven in bounds, and every returned range is proven valid. The specifications live in `src/parse.rs` alongside the code they verify, inside a `verus!` macro block. Under normal `cargo build`, the specs are erased. Under `cargo verus build`, all conditions are machine-checked.
+The parser functions (boot chain check, BLS entry parsing, mount option extraction) are formally verified inline using [Verus](https://github.com/verus-lang/verus). Every loop is proven to terminate, every array access is proven in bounds, and every returned range is proven valid. The specifications live in `src/parse.rs` alongside the code they verify, inside a `verus!` macro block. Under normal `cargo build`, the specs are erased. Under `cargo verus build`, all conditions are machine-checked.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The /boot/grub2 directory is set to NOCOW (chattr +C) and grubenv is recreated. 
 
 save_env is stripped from grub.cfg. GRUB's Btrfs driver is read-only. save_env requires write access. Since writing is impossible, save_env is a guaranteed failure. Removing it prevents an error message on every boot.
 
-A kernel-install hook is installed. When new kernels are installed via dnf, the hook creates symlinks and ensures boot entry paths are correct. This keeps the system bootable across kernel updates.
+A kernel-install hook is written by `migrate` as a migration artifact. When new kernels are installed, the hook creates symlinks and ensures boot entry paths are correct. This keeps the system bootable across kernel updates. The hook persists after package removal because `migrate` owns it, not the RPM.
 
 ## Automatic snapshots
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo atomic-rollback rollback
 sudo reboot
 ```
 
-Snapshots are automatic via the RPM plugin (covers dnf, rpm, and any RPM-based package manager). Manual snapshots are still available for non-RPM changes: `sudo atomic-rollback snapshot create [name]`.
+Snapshots are automatic via the RPM plugin (covers dnf, rpm, and any RPM-based package manager). Each transaction creates a new timestamped snapshot. Old automatic snapshots are removed when the count exceeds MAX_SNAPSHOTS (default 50, configurable in `/etc/atomic-rollback.conf`). User-named snapshots are never automatically removed. Manual snapshots are still available for non-RPM changes: `sudo atomic-rollback snapshot create [name]`.
 
 ## Commands
 
@@ -79,7 +79,7 @@ A kernel-install hook is written by `migrate` as a migration artifact. When new 
 
 ## Automatic snapshots
 
-An RPM plugin snapshots the root subvolume before every RPM transaction (dnf, rpm, PackageKit, or any other RPM-based frontend). If the snapshot cannot be created, the transaction aborts. If a snapshot already exists, the transaction proceeds with the existing protection.
+An RPM plugin snapshots the root subvolume before every RPM transaction (dnf, rpm, PackageKit, or any other RPM-based frontend). If the snapshot cannot be created, the transaction aborts. When the number of automatic snapshots exceeds MAX_SNAPSHOTS, the oldest are removed. User-named snapshots are never counted against this limit and are never automatically removed. MAX_SNAPSHOTS defaults to 50 and can be changed in `/etc/atomic-rollback.conf`.
 
 ## Guarantees
 

--- a/atomic-rollback.conf
+++ b/atomic-rollback.conf
@@ -1,0 +1,8 @@
+# atomic-rollback configuration
+
+# Maximum number of automatic snapshots to retain.
+# Automatic snapshots are created on every RPM transaction.
+# When this limit is exceeded, the oldest automatic snapshot is removed.
+# User-named snapshots (created with `atomic-rollback snapshot create <name>`)
+# are not counted and are never automatically removed.
+MAX_SNAPSHOTS=50

--- a/atomic-rollback.spec
+++ b/atomic-rollback.spec
@@ -19,7 +19,6 @@ Requires:       grub2-tools
 Requires:       dracut
 Requires:       util-linux
 Requires:       systemd
-Requires:       libdnf5-plugin-actions
 
 ExclusiveArch:  x86_64 aarch64
 
@@ -44,7 +43,6 @@ cargo test --release --offline
 %install
 install -Dm755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
 install -Dm755 hooks/90-%{name}.install %{buildroot}%{_prefix}/lib/kernel/install.d/90-%{name}.install
-install -Dm644 plugins/%{name}.actions %{buildroot}%{_sysconfdir}/dnf/libdnf5-plugins/actions.d/%{name}.actions
 install -Dm755 atomic_rollback.so %{buildroot}%{__plugindir}/atomic_rollback.so
 install -Dm644 plugins/macros.transaction_atomic_rollback %{buildroot}/usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
 
@@ -53,7 +51,6 @@ install -Dm644 plugins/macros.transaction_atomic_rollback %{buildroot}/usr/lib/r
 %doc README.md
 %{_bindir}/%{name}
 %{_prefix}/lib/kernel/install.d/90-%{name}.install
-%config(noreplace) %{_sysconfdir}/dnf/libdnf5-plugins/actions.d/%{name}.actions
 %{__plugindir}/atomic_rollback.so
 /usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
 

--- a/atomic-rollback.spec
+++ b/atomic-rollback.spec
@@ -42,7 +42,6 @@ cargo test --release --offline
 
 %install
 install -Dm755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
-install -Dm755 hooks/90-%{name}.install %{buildroot}%{_prefix}/lib/kernel/install.d/90-%{name}.install
 install -Dm755 atomic_rollback.so %{buildroot}%{__plugindir}/atomic_rollback.so
 install -Dm644 plugins/macros.transaction_atomic_rollback %{buildroot}/usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
 
@@ -50,8 +49,11 @@ install -Dm644 plugins/macros.transaction_atomic_rollback %{buildroot}/usr/lib/r
 %license LICENSE
 %doc README.md
 %{_bindir}/%{name}
-%{_prefix}/lib/kernel/install.d/90-%{name}.install
 %{__plugindir}/atomic_rollback.so
 /usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
+
+%posttrans -p /bin/sh
+/usr/bin/atomic-rollback ensure-hooks 2>/dev/null || :
+exit 0
 
 %changelog

--- a/atomic-rollback.spec
+++ b/atomic-rollback.spec
@@ -44,6 +44,7 @@ cargo test --release --offline
 install -Dm755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
 install -Dm755 atomic_rollback.so %{buildroot}%{__plugindir}/atomic_rollback.so
 install -Dm644 plugins/macros.transaction_atomic_rollback %{buildroot}/usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
+install -Dm644 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}.conf
 
 %files
 %license LICENSE
@@ -51,6 +52,7 @@ install -Dm644 plugins/macros.transaction_atomic_rollback %{buildroot}/usr/lib/r
 %{_bindir}/%{name}
 %{__plugindir}/atomic_rollback.so
 /usr/lib/rpm/macros.d/macros.transaction_atomic_rollback
+%config(noreplace) %{_sysconfdir}/%{name}.conf
 
 %posttrans -p /bin/sh
 /usr/bin/atomic-rollback ensure-hooks 2>/dev/null || :

--- a/atomic-rollback.spec
+++ b/atomic-rollback.spec
@@ -55,6 +55,7 @@ install -Dm644 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/%{name}.conf
 
 %posttrans -p /bin/sh
+/usr/bin/atomic-rollback rename-legacy-snapshot 2>/dev/null || :
 /usr/bin/atomic-rollback ensure-hooks 2>/dev/null || :
 exit 0
 

--- a/plugins/atomic-rollback.actions
+++ b/plugins/atomic-rollback.actions
@@ -1,6 +1,0 @@
-# Automatically snapshot the root subvolume before every dnf transaction.
-# If a snapshot already exists, the command exits 0 (idempotent).
-# If the snapshot cannot be created, dnf aborts (raise_error=1).
-# Install: /etc/dnf/libdnf5-plugins/actions.d/atomic-rollback.actions
-# Requires: libdnf5-plugin-actions atomic-rollback
-pre_transaction:::raise_error=1:atomic-rollback snapshot

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,4 +1,4 @@
-//! BOOTS predicate: evaluates whether the system is bootable by tracing
+//! BOOTS predicate: evaluates whether the boot chain is valid by tracing
 //! the boot chain from UEFI firmware through GRUB to the root filesystem.
 //! Each check corresponds to a link in the chain:
 //!   UEFI -> shim -> GRUB -> grub.cfg -> BLS entries -> kernel -> root mount -> fstab

--- a/src/check.rs
+++ b/src/check.rs
@@ -457,6 +457,46 @@ fn check_btrfs_subvol_exists(device_spec: &tools::DeviceSpec, name: &tools::Subv
     }
 }
 
+pub fn print_rollback_scope(fstab: &str) {
+    let lines = tools::parse_fstab(fstab);
+    let entries = tools::fstab_entries(&lines);
+
+    let protected: Vec<&str> = entries.iter()
+        .filter(|e| e.fs_file != "/")
+        .filter(|e| parse::extract_mount_option(&e.fs_mntops, "subvol").is_some())
+        .map(|e| e.fs_file.as_str())
+        .collect();
+
+    println!("  Rollback scope:\n");
+
+    if !protected.is_empty() {
+        println!("  SAFE  Separate subvolumes (not affected by rollback):");
+        for p in &protected {
+            println!("        {p}");
+        }
+        println!();
+    }
+
+    let at_risk: Vec<String> = match fs::read_dir("/") {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_ok_and(|ft| ft.is_dir()))
+            .map(|e| format!("/{}", e.file_name().to_string_lossy()))
+            .filter(|dir| !tools::is_mountpoint(Path::new(dir)))
+            .filter(|dir| fs::read_dir(dir).is_ok_and(|mut d| d.next().is_some()))
+            .collect(),
+        Err(_) => vec![],
+    };
+
+    if !at_risk.is_empty() {
+        println!("  RISK  Inside root subvolume (will revert on rollback):");
+        for r in &at_risk {
+            println!("        {r}");
+        }
+        println!();
+    }
+}
+
 fn extract_root_uuid(root: &Path) -> Option<tools::BareUuid> {
     let entries_dir = root.join(&P.bls_dir[1..]);
     for entry in fs::read_dir(&entries_dir).ok()?.flatten() {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,6 +1,6 @@
 //! Shared constants used across multiple modules.
 
-// Default snapshot name, used by the dnf plugin and bare `snapshot` command.
+// Default snapshot name, used by the RPM plugin and bare `snapshot` command.
 pub const DEFAULT_SNAPSHOT_NAME: &str = "root.pre-update";
 
 // Temporary mount point for the btrfs top-level subvolume.

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,8 +1,5 @@
 //! Shared constants used across multiple modules.
 
-// Default snapshot name, used by the RPM plugin and bare `snapshot` command.
-pub const DEFAULT_SNAPSHOT_NAME: &str = "root.pre-update";
-
 // Temporary mount point for the btrfs top-level subvolume.
 pub const TOPLEVEL_MOUNT: &str = "/mnt/atomic-rollback-toplevel";
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -12,3 +12,10 @@ pub const PROBE_MOUNT_PREFIX: &str = "/tmp/atomic-rollback-probe-";
 // Btrfs top-level subvolume ID. Always 5 by definition.
 // All user subvolumes (root, home, var) are children of this.
 pub const BTRFS_TOPLEVEL_SUBVOLID: u64 = 5;
+
+// Configuration file path. Shell key=value format.
+pub const CONFIG_PATH: &str = "/etc/atomic-rollback.conf";
+
+// Maximum number of automatic snapshots to retain. Overridden by
+// MAX_SNAPSHOTS in CONFIG_PATH if present.
+pub const MAX_SNAPSHOTS: usize = 50;

--- a/src/kernel_hook.rs
+++ b/src/kernel_hook.rs
@@ -7,6 +7,51 @@ use std::path::Path;
 
 use crate::{check, parse, platform::FEDORA as P, swap, tools};
 
+const HOOK_PATH: &str = "/usr/lib/kernel/install.d/90-atomic-rollback.install";
+const HOOK_CONTENT: &str = "#!/usr/bin/bash\n\
+# kernel-install plugin for atomic-rollback.\n\
+# Thin dispatcher. All logic lives in the Rust binary, inside the proof boundary.\n\
+exec /usr/bin/atomic-rollback kernel-hook \"$@\"\n";
+
+/// Writes the kernel-install hook if the system is migrated and the hook is missing.
+/// Called by `migrate` (as a migration artifact) and by `ensure-hooks` (for upgrades).
+/// Non-fatal: logs errors but always returns Ok for use in %posttrans context.
+pub fn ensure_hooks() {
+    let root_fstype = match tools::run_stdout("findmnt", &["-n", "-o", "FSTYPE", "/"]) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    if root_fstype != "btrfs" {
+        return;
+    }
+    if tools::is_mountpoint(Path::new("/boot")) {
+        return;
+    }
+
+    let hook = Path::new(HOOK_PATH);
+    if hook.exists() {
+        return;
+    }
+
+    if let Some(parent) = hook.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            eprintln!("atomic-rollback: cannot create {}: {e}", parent.display());
+            return;
+        }
+    }
+
+    if let Err(e) = fs::write(hook, HOOK_CONTENT) {
+        eprintln!("atomic-rollback: cannot write {HOOK_PATH}: {e}");
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(hook, fs::Permissions::from_mode(0o755));
+    }
+}
+
 /// Dispatched by /usr/lib/kernel/install.d/90-atomic-rollback.install.
 /// Only acts when root is btrfs and /boot is not a separate mount
 /// (i.e. the full migration has been applied).

--- a/src/kernel_hook.rs
+++ b/src/kernel_hook.rs
@@ -88,7 +88,7 @@ fn handle_add(kver: &str) -> Result<(), String> {
     // Symlinks and BLS swap are in the btrfs in-memory journal only.
     tools::sync_filesystem("/")?;
 
-    // Gate: verify the system is still bootable.
+    // Gate: verify the boot chain is still valid.
     match check::verify_bootable(Path::new("/")) {
         check::BootStatus::Pass | check::BootStatus::Warn => Ok(()),
         check::BootStatus::Fail(failures) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,12 +189,15 @@ fn main() {
             }
             SnapshotCommand::List => {
                 match snapshot::list() {
-                    Ok(names) => {
-                        if names.is_empty() {
+                    Ok(snapshots) => {
+                        if snapshots.is_empty() {
                             eprintln!("No snapshots found.");
                         } else {
-                            for name in &names {
-                                println!("{name}");
+                            let id_w = snapshots.iter().map(|s| s.id.to_string().len()).max().unwrap_or(2).max(2);
+                            let name_w = snapshots.iter().map(|s| s.name.len()).max().unwrap_or(4).max(4);
+                            println!("{:<id_w$}  {:<name_w$}  {}", "ID", "Name", "Created");
+                            for s in &snapshots {
+                                println!("{:<id_w$}  {:<name_w$}  {}", s.id, s.name, s.created);
                             }
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ enum Command {
     Snapshot(SnapshotCommand),
     Rollback { name: String },
     KernelHook { command: String, kver: String },
+    EnsureHooks,
 }
 
 enum SnapshotCommand {
@@ -115,6 +116,7 @@ fn parse_args(args: &[String]) -> Command {
                 name: args.get(2).cloned().unwrap_or_else(|| consts::DEFAULT_SNAPSHOT_NAME.into()),
             }
         }
+        "ensure-hooks" => Command::EnsureHooks,
         "kernel-hook" => {
             // kernel-install calls hooks for events we may not handle.
             // Missing args = nothing to do.
@@ -219,6 +221,9 @@ fn main() {
                 std::process::exit(1);
             }
             println!("Rollback complete. Reboot to activate.");
+        }
+        Command::EnsureHooks => {
+            kernel_hook::ensure_hooks();
         }
         Command::KernelHook { command, kver } => {
             if let Err(e) = kernel_hook::handle(&command, &kver) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ enum Command {
     Rollback { name: Option<String> },
     KernelHook { command: String, kver: String },
     EnsureHooks,
+    RenameLegacySnapshot,
 }
 
 enum SnapshotCommand {
@@ -117,6 +118,7 @@ fn parse_args(args: &[String]) -> Command {
             }
         }
         "ensure-hooks" => Command::EnsureHooks,
+        "rename-legacy-snapshot" => Command::RenameLegacySnapshot,
         "kernel-hook" => {
             // kernel-install calls hooks for events we may not handle.
             // Missing args = nothing to do.
@@ -241,6 +243,9 @@ fn main() {
         }
         Command::EnsureHooks => {
             kernel_hook::ensure_hooks();
+        }
+        Command::RenameLegacySnapshot => {
+            snapshot::rename_legacy_snapshot();
         }
         Command::KernelHook { command, kver } => {
             if let Err(e) = kernel_hook::handle(&command, &kver) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn print_help() {
     eprintln!("atomic-rollback: atomic system rollback for Fedora via Btrfs subvolume swap");
     eprintln!();
     eprintln!("usage:");
-    eprintln!("  atomic-rollback check                verify the system is bootable");
+    eprintln!("  atomic-rollback check                verify the boot chain is valid");
     eprintln!("  atomic-rollback setup                separate /var, enable snapshots and rollback");
     eprintln!("  atomic-rollback migrate              full boot migration for complete kernel rollback");
     eprintln!("  atomic-rollback snapshot             create snapshot (auto-named)");
@@ -143,18 +143,18 @@ fn main() {
 
     match parse_args(&args) {
         Command::Check { root } => {
-            println!("atomic-rollback: checking system bootability\n");
+            println!("atomic-rollback: verifying boot chain\n");
             match check::verify_bootable(Path::new(&root)) {
                 check::BootStatus::Pass => {
-                    println!("\nSystem is bootable.");
+                    println!("\nBoot chain is valid.");
                 }
                 check::BootStatus::Warn => {
-                    println!("\nSystem is bootable (with warnings).");
+                    println!("\nBoot chain is valid (with warnings).");
                     std::process::exit(2);
                 }
                 check::BootStatus::Fail(failures) => {
                     for f in &failures { eprintln!("  {f}"); }
-                    println!("\nSystem has boot problems.");
+                    println!("\nBoot chain has problems.");
                     std::process::exit(1);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,10 +156,16 @@ fn main() {
             println!("atomic-rollback: verifying boot chain\n");
             match check::verify_bootable(Path::new(&root)) {
                 check::BootStatus::Pass => {
-                    println!("\nBoot chain is valid.");
+                    println!("\nBoot chain is valid.\n");
+                    if let Ok((_, fstab)) = tools::root_device() {
+                        check::print_rollback_scope(&fstab);
+                    }
                 }
                 check::BootStatus::Warn => {
-                    println!("\nBoot chain is valid (with warnings).");
+                    println!("\nBoot chain is valid (with warnings).\n");
+                    if let Ok((_, fstab)) = tools::root_device() {
+                        check::print_rollback_scope(&fstab);
+                    }
                     std::process::exit(2);
                 }
                 check::BootStatus::Fail(failures) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ enum Command {
     Setup,
     Migrate,
     Snapshot(SnapshotCommand),
-    Rollback { name: String },
+    Rollback { name: Option<String> },
     KernelHook { command: String, kver: String },
     EnsureHooks,
 }
@@ -47,8 +47,8 @@ fn print_help() {
     eprintln!("  atomic-rollback snapshot             create snapshot (auto-named)");
     eprintln!("  atomic-rollback snapshot create [N]  create snapshot with optional name");
     eprintln!("  atomic-rollback snapshot list        show available snapshots");
-    eprintln!("  atomic-rollback snapshot delete <N>  delete a snapshot by name");
-    eprintln!("  atomic-rollback rollback [name]      roll back to a snapshot");
+    eprintln!("  atomic-rollback snapshot delete <N>  delete a snapshot by ID or name");
+    eprintln!("  atomic-rollback rollback [id|name]    roll back to a snapshot");
 }
 
 fn print_snapshot_help() {
@@ -56,7 +56,7 @@ fn print_snapshot_help() {
     eprintln!("  atomic-rollback snapshot             create snapshot (auto-named)");
     eprintln!("  atomic-rollback snapshot create [N]  create snapshot with optional name");
     eprintln!("  atomic-rollback snapshot list        show available snapshots");
-    eprintln!("  atomic-rollback snapshot delete <N>  delete a snapshot by name");
+    eprintln!("  atomic-rollback snapshot delete <N>  delete a snapshot by ID or name");
 }
 
 // --- Parsing ---
@@ -81,7 +81,7 @@ fn parse_snapshot(args: &[String]) -> SnapshotCommand {
             match args.get(3) {
                 Some(name) => SnapshotCommand::Delete { name: name.clone() },
                 None => {
-                    eprintln!("Usage: atomic-rollback snapshot delete <name>");
+                    eprintln!("Usage: atomic-rollback snapshot delete <id|name>");
                     std::process::exit(2);
                 }
             }
@@ -113,7 +113,7 @@ fn parse_args(args: &[String]) -> Command {
         "rollback" => {
             if is_help(args.get(2)) { print_help(); std::process::exit(0); }
             Command::Rollback {
-                name: args.get(2).cloned().unwrap_or_else(|| consts::DEFAULT_SNAPSHOT_NAME.into()),
+                name: args.get(2).cloned(),
             }
         }
         "ensure-hooks" => Command::EnsureHooks,
@@ -208,8 +208,12 @@ fn main() {
                 }
             }
             SnapshotCommand::Delete { name } => {
-                match snapshot::delete(&name) {
-                    Ok(id) => eprintln!("Snapshot '{name}' with ID {id} deleted."),
+                let (resolved, _) = match snapshot::resolve_snapshot(&name) {
+                    Ok(r) => r,
+                    Err(e) => { eprintln!("Snapshot delete failed: {e}"); std::process::exit(1); }
+                };
+                match snapshot::delete(&resolved) {
+                    Ok(id) => eprintln!("Snapshot '{resolved}' with ID {id} deleted."),
                     Err(e) => {
                         eprintln!("Snapshot delete failed: {e}");
                         std::process::exit(1);
@@ -218,7 +222,17 @@ fn main() {
             }
         }
         Command::Rollback { name } => {
-            println!("atomic-rollback: rolling back to '{name}'\n");
+            let (name, id) = match name {
+                Some(arg) => match snapshot::resolve_snapshot(&arg) {
+                    Ok(r) => r,
+                    Err(e) => { eprintln!("Rollback failed: {e}"); std::process::exit(1); }
+                },
+                None => match snapshot::most_recent_snapshot() {
+                    Ok(r) => r,
+                    Err(e) => { eprintln!("Rollback failed: {e}"); std::process::exit(1); }
+                },
+            };
+            println!("atomic-rollback: rolling back to '{name}' (ID {id})\n");
             if let Err(e) = rollback::rollback(&name) {
                 eprintln!("Rollback failed: {e}");
                 std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,10 @@ fn is_help(arg: Option<&String>) -> bool {
     arg.is_some_and(|a| a == "--help" || a == "-h")
 }
 
+fn is_version(arg: Option<&String>) -> bool {
+    arg.is_some_and(|a| a == "--version" || a == "-V")
+}
+
 fn parse_snapshot(args: &[String]) -> SnapshotCommand {
     if is_help(args.get(2)) {
         print_snapshot_help();
@@ -98,6 +102,10 @@ fn parse_snapshot(args: &[String]) -> SnapshotCommand {
 }
 
 fn parse_args(args: &[String]) -> Command {
+    if is_version(args.get(1)) {
+        println!("atomic-rollback v{}", env!("CARGO_PKG_VERSION"));
+        std::process::exit(0);
+    }
     if args.len() < 2 || is_help(args.get(1)) {
         print_help();
         std::process::exit(if args.len() < 2 { 2 } else { 0 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn print_help() {
     eprintln!("  atomic-rollback check                verify the system is bootable");
     eprintln!("  atomic-rollback setup                separate /var, enable snapshots and rollback");
     eprintln!("  atomic-rollback migrate              full boot migration for complete kernel rollback");
-    eprintln!("  atomic-rollback snapshot             create snapshot (default name)");
+    eprintln!("  atomic-rollback snapshot             create snapshot (auto-named)");
     eprintln!("  atomic-rollback snapshot create [N]  create snapshot with optional name");
     eprintln!("  atomic-rollback snapshot list        show available snapshots");
     eprintln!("  atomic-rollback snapshot delete <N>  delete a snapshot by name");
@@ -53,7 +53,7 @@ fn print_help() {
 
 fn print_snapshot_help() {
     eprintln!("usage:");
-    eprintln!("  atomic-rollback snapshot             create snapshot (default name)");
+    eprintln!("  atomic-rollback snapshot             create snapshot (auto-named)");
     eprintln!("  atomic-rollback snapshot create [N]  create snapshot with optional name");
     eprintln!("  atomic-rollback snapshot list        show available snapshots");
     eprintln!("  atomic-rollback snapshot delete <N>  delete a snapshot by name");

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,10 +176,10 @@ fn main() {
         Command::Snapshot(sub) => match sub {
             SnapshotCommand::Create { name } => {
                 match snapshot::snapshot(name.as_deref()) {
-                    Ok(snapshot::SnapshotResult::Created(name)) =>
-                        eprintln!("Snapshot '{name}' created."),
-                    Ok(snapshot::SnapshotResult::Existed(name)) =>
-                        eprintln!("Snapshot '{name}' already exists."),
+                    Ok(snapshot::SnapshotResult::Created(name, id)) =>
+                        eprintln!("Snapshot '{name}' with ID {id} created."),
+                    Ok(snapshot::SnapshotResult::Existed(name, id)) =>
+                        eprintln!("Snapshot '{name}' with ID {id} already exists."),
                     Ok(snapshot::SnapshotResult::NotBtrfs) => {}
                     Err(e) => {
                         eprintln!("Snapshot failed: {e}");
@@ -206,7 +206,7 @@ fn main() {
             }
             SnapshotCommand::Delete { name } => {
                 match snapshot::delete(&name) {
-                    Ok(()) => eprintln!("Deleted snapshot '{name}'."),
+                    Ok(id) => eprintln!("Snapshot '{name}' with ID {id} deleted."),
                     Err(e) => {
                         eprintln!("Snapshot delete failed: {e}");
                         std::process::exit(1);

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -79,6 +79,8 @@ pub fn migrate() -> Result<(), String> {
     // and set-default are in the btrfs in-memory journal only.
     tools::sync_filesystem("/")?;
 
+    crate::kernel_hook::ensure_hooks();
+
     println!("Migration complete. All gates passed.");
     Ok(())
 }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -32,7 +32,7 @@ pub fn setup() -> Result<(), String> {
     tools::sync_filesystem("/")?;
 
     println!("Setup complete. Snapshots and rollback are enabled.");
-    println!("Install the dnf plugin for automatic pre-update snapshots.");
+    println!("The RPM plugin creates automatic pre-update snapshots.");
     Ok(())
 }
 

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -41,6 +41,8 @@ pub fn rollback(snapshot_name: &str) -> Result<(), String> {
         }
     }
 
+    check::print_rollback_scope(&fstab);
+
     // RENAME_EXCHANGE: root_subvol <-> snapshot
     println!("  RENAME_EXCHANGE: {root_subvol} <-> {snapshot_name}");
     swap::rename_exchange(Path::new(toplevel), root_subvol.as_str(), snapshot_name)?;

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -1,4 +1,4 @@
-//! Rollback: verify snapshot is bootable, swap root subvolume names
+//! Rollback: verify boot chain for snapshot, swap root subvolume names
 //! via RENAME_EXCHANGE, update default subvolume. Undoes the swap
 //! if set-default fails.
 
@@ -25,7 +25,7 @@ pub fn rollback(snapshot_name: &str) -> Result<(), String> {
         return Err(format!("snapshot '{snapshot_name}' not found at top-level"));
     }
 
-    println!("\n  Verifying snapshot '{snapshot_name}' is bootable...");
+    println!("\n  Verifying boot chain for snapshot '{snapshot_name}'...");
     match check::verify_snapshot_bootable(Path::new(&snapshot_path)) {
         check::BootStatus::Pass | check::BootStatus::Warn => {
             println!("  Snapshot verified.\n");
@@ -37,7 +37,7 @@ pub fn rollback(snapshot_name: &str) -> Result<(), String> {
             }
             tools::umount(toplevel)?;
             let _ = std::fs::remove_dir(toplevel);
-            return Err("rollback aborted: snapshot is not bootable".into());
+            return Err("rollback aborted: boot chain invalid for snapshot".into());
         }
     }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -5,8 +5,28 @@
 use std::fs;
 use std::path::Path;
 
-use crate::consts::DEFAULT_SNAPSHOT_NAME;
 use crate::{parse, tools};
+
+/// Generates an auto-name for automatic snapshots using local time.
+/// Format: %Y-%m-%d_%H-%M-%S (e.g., "2026-04-11_15-30-07").
+fn generate_auto_name() -> String {
+    let now: std::time::SystemTime = std::time::SystemTime::now();
+    let duration = now.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+    let secs = duration.as_secs() as i64;
+
+    let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+    unsafe { libc::localtime_r(&secs as *const i64, &mut tm) };
+
+    format!(
+        "{:04}-{:02}-{:02}_{:02}-{:02}-{:02}",
+        tm.tm_year + 1900,
+        tm.tm_mon + 1,
+        tm.tm_mday,
+        tm.tm_hour,
+        tm.tm_min,
+        tm.tm_sec,
+    )
+}
 
 /// Result of a snapshot operation.
 pub enum SnapshotResult {
@@ -16,10 +36,14 @@ pub enum SnapshotResult {
 }
 
 /// Creates a snapshot of the root subvolume at the btrfs top level.
-/// Idempotent: returns Existed if the snapshot already exists.
+/// Auto-generates a timestamped name if none is given.
+/// Returns Existed if a snapshot with the same name already exists.
 /// Returns NotBtrfs if the root filesystem is not btrfs (nothing to protect).
 pub fn snapshot(name: Option<&str>) -> Result<SnapshotResult, String> {
-    let name = name.unwrap_or(DEFAULT_SNAPSHOT_NAME);
+    let name = match name {
+        Some(n) => n.to_string(),
+        None => generate_auto_name(),
+    };
     let (_, fstab) = tools::root_device()?;
     let root_subvol = match tools::root_subvol_name(&fstab) {
         Ok(s) => s,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,11 +1,88 @@
-//! Snapshot lifecycle: create, list, delete. The RPM plugin calls
-//! create before every transaction. List and delete delegate to
-//! btrfs-progs; delete adds an fstab guard that btrfs-progs lacks.
+//! Snapshot lifecycle: create, list, delete, retain. The RPM plugin
+//! calls create before every transaction. Retention evicts the oldest
+//! automatic snapshots when the count exceeds MAX_SNAPSHOTS. List and
+//! delete delegate to btrfs-progs; delete adds an fstab guard that
+//! btrfs-progs lacks.
 
 use std::fs;
 use std::path::Path;
 
-use crate::{parse, tools};
+use crate::{consts, parse, tools};
+
+/// Returns true if a name matches the auto-generated snapshot format (YYYY-MM-DD_HH-MM-SS).
+fn is_auto_name(name: &str) -> bool {
+    if name.len() != 19 { return false; }
+    let b = name.as_bytes();
+    b[0..4].iter().all(u8::is_ascii_digit)
+        && b[4] == b'-' && b[7] == b'-' && b[10] == b'_'
+        && b[13] == b'-' && b[16] == b'-'
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[8..10].iter().all(u8::is_ascii_digit)
+        && b[11..13].iter().all(u8::is_ascii_digit)
+        && b[14..16].iter().all(u8::is_ascii_digit)
+        && b[17..19].iter().all(u8::is_ascii_digit)
+}
+
+/// Parses MAX_SNAPSHOTS from config file content.
+fn parse_max_snapshots(content: &str) -> usize {
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("MAX_SNAPSHOTS=") {
+            let value = value.trim().trim_matches('"');
+            if let Ok(n) = value.parse::<usize>() {
+                return n;
+            }
+        }
+    }
+    consts::MAX_SNAPSHOTS
+}
+
+/// Reads MAX_SNAPSHOTS from the config file, falling back to the compiled-in default.
+fn max_snapshots() -> usize {
+    match fs::read_to_string(consts::CONFIG_PATH) {
+        Ok(content) => parse_max_snapshots(&content),
+        Err(_) => consts::MAX_SNAPSHOTS,
+    }
+}
+
+/// Evicts the oldest auto-named snapshots if count exceeds MAX_SNAPSHOTS.
+/// User-named snapshots are never touched. Failures are logged, not fatal.
+fn retain_auto_snapshots() {
+    let max = max_snapshots();
+    if max == 0 { return; }
+
+    let protected = match fstab_subvol_names() {
+        Ok(p) => p,
+        Err(e) => { eprintln!("Retention warning: {e}"); return; }
+    };
+    let entries = match tools::btrfs_subvol_list("/") {
+        Ok(e) => e,
+        Err(e) => { eprintln!("Retention warning: {e}"); return; }
+    };
+
+    let mut auto_entries: Vec<&tools::SubvolEntry> = entries.iter()
+        .filter(|e| is_auto_name(&e.path))
+        .filter(|e| !protected.iter().any(|p| p.as_str() == e.path))
+        .collect();
+
+    if auto_entries.len() <= max {
+        return;
+    }
+
+    auto_entries.sort_by_key(|e| e.id);
+    let to_evict = auto_entries.len() - max;
+
+    eprintln!("Keeping {max} automatic snapshots, removing oldest.");
+    for entry in auto_entries.iter().take(to_evict) {
+        match delete(&entry.path) {
+            Ok(..) => eprintln!("Snapshot '{}' with ID {} removed.", entry.path, entry.id),
+            Err(e) => eprintln!("Warning: failed to remove '{}': {e}", entry.path),
+        }
+    }
+}
 
 /// Generates an auto-name for automatic snapshots using local time.
 /// Format: %Y-%m-%d_%H-%M-%S (e.g., "2026-04-11_15-30-07").
@@ -40,8 +117,16 @@ pub enum SnapshotResult {
 /// Returns Existed if a snapshot with the same name already exists.
 /// Returns NotBtrfs if the root filesystem is not btrfs (nothing to protect).
 pub fn snapshot(name: Option<&str>) -> Result<SnapshotResult, String> {
+    let is_auto = name.is_none();
     let name = match name {
-        Some(n) => n.to_string(),
+        Some(n) => {
+            if is_auto_name(n) {
+                return Err(format!(
+                    "Name '{n}' uses the format reserved for automatic snapshots. \
+                     Choose a different name."));
+            }
+            n.to_string()
+        }
         None => generate_auto_name(),
     };
     let (_, fstab) = tools::root_device()?;
@@ -50,14 +135,22 @@ pub fn snapshot(name: Option<&str>) -> Result<SnapshotResult, String> {
         Err(_) => return Ok(SnapshotResult::NotBtrfs),
     };
 
-    tools::with_toplevel(|toplevel| {
+    let result = tools::with_toplevel(|toplevel| {
         let snap_path = format!("{toplevel}/{name}");
         if Path::new(&snap_path).exists() {
             return Ok(SnapshotResult::Existed(name.to_string()));
         }
         tools::btrfs_subvol_snapshot(&format!("{toplevel}/{}", root_subvol.as_str()), &snap_path)?;
         Ok(SnapshotResult::Created(name.to_string()))
-    })
+    })?;
+
+    if is_auto {
+        if let SnapshotResult::Created(_) = &result {
+            retain_auto_snapshots();
+        }
+    }
+
+    Ok(result)
 }
 
 /// Returns top-level subvolume names, excluding fstab system subvolumes.
@@ -143,6 +236,30 @@ UUID=abc /home btrfs subvol=home 0 0";
         let names = fstab_subvol_names_from(fstab);
         let names: Vec<&str> = names.iter().map(|n| n.as_str()).collect();
         assert_eq!(names, vec!["root", "home"]);
+    }
+
+    #[test]
+    fn auto_name_detection() {
+        assert!(super::is_auto_name("2026-04-11_15-30-07"));
+        assert!(super::is_auto_name("1999-01-01_00-00-00"));
+        assert!(!super::is_auto_name("my-snapshot"));
+        assert!(!super::is_auto_name("root.pre-update"));
+        assert!(!super::is_auto_name("2026-04-11_15-30-0"));  // 18 chars
+        assert!(!super::is_auto_name("2026-04-11_15-30-070")); // 20 chars
+        assert!(!super::is_auto_name("2026-04-11 15:30:07")); // wrong separators
+        assert!(!super::is_auto_name("abcd-ef-gh_ij-kl-mn")); // letters
+    }
+
+    #[test]
+    fn config_parsing() {
+        assert_eq!(super::parse_max_snapshots("MAX_SNAPSHOTS=50"), 50);
+        assert_eq!(super::parse_max_snapshots("MAX_SNAPSHOTS=10"), 10);
+        assert_eq!(super::parse_max_snapshots("MAX_SNAPSHOTS=\"25\""), 25);
+        assert_eq!(super::parse_max_snapshots("# comment\nMAX_SNAPSHOTS=30\n"), 30);
+        assert_eq!(super::parse_max_snapshots(""), crate::consts::MAX_SNAPSHOTS);
+        assert_eq!(super::parse_max_snapshots("MAX_SNAPSHOTS=abc"), crate::consts::MAX_SNAPSHOTS);
+        assert_eq!(super::parse_max_snapshots("OTHER_KEY=50"), crate::consts::MAX_SNAPSHOTS);
+        assert_eq!(super::parse_max_snapshots("MAX_SNAPSHOTS=0"), 0);
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -192,6 +192,35 @@ pub fn list() -> Result<Vec<SnapshotInfo>, String> {
     Ok(snapshots)
 }
 
+/// Resolves a snapshot argument to (name, id).
+/// Numeric arguments are resolved as btrfs subvolume IDs.
+/// Non-numeric arguments are resolved as snapshot names.
+pub fn resolve_snapshot(arg: &str) -> Result<(String, u64), String> {
+    let entries = tools::btrfs_subvol_list("/")?;
+    if let Ok(id) = arg.parse::<u64>() {
+        entries.iter()
+            .find(|e| e.id == id)
+            .map(|e| (e.path.clone(), e.id))
+            .ok_or_else(|| format!("no snapshot with ID {id}"))
+    } else {
+        entries.iter()
+            .find(|e| e.path == arg)
+            .map(|e| (e.path.clone(), e.id))
+            .ok_or_else(|| format!("snapshot '{arg}' not found"))
+    }
+}
+
+/// Returns the most recent snapshot (highest btrfs subvolume ID), excluding system subvolumes.
+pub fn most_recent_snapshot() -> Result<(String, u64), String> {
+    let protected = fstab_subvol_names()?;
+    let entries = tools::btrfs_subvol_list("/")?;
+    entries.iter()
+        .filter(|e| !protected.iter().any(|p| p.as_str() == e.path))
+        .max_by_key(|e| e.id)
+        .map(|e| (e.path.clone(), e.id))
+        .ok_or_else(|| "no snapshots found".to_string())
+}
+
 /// Refuses subvolumes referenced by fstab (system subvolumes).
 /// Mounted and default subvolume protection from kernel and btrfs-progs.
 pub fn delete(name: &str) -> Result<u64, String> {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,4 +1,4 @@
-//! Snapshot lifecycle: create, list, delete. The dnf plugin calls
+//! Snapshot lifecycle: create, list, delete. The RPM plugin calls
 //! create before every transaction. List and delete delegate to
 //! btrfs-progs; delete adds an fstab guard that btrfs-progs lacks.
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -157,15 +157,38 @@ pub fn snapshot(name: Option<&str>) -> Result<SnapshotResult, String> {
     }
 }
 
-/// Returns top-level subvolume names, excluding fstab system subvolumes.
-pub fn list() -> Result<Vec<String>, String> {
+/// Snapshot metadata for the list command.
+pub struct SnapshotInfo {
+    pub id: u64,
+    pub name: String,
+    pub created: String,
+}
+
+/// Returns snapshot info (ID, name, creation time), excluding fstab system subvolumes.
+/// Sorted by ID ascending (chronological order).
+pub fn list() -> Result<Vec<SnapshotInfo>, String> {
     let protected = fstab_subvol_names()?;
     let entries = tools::btrfs_subvol_list("/")?;
-    let mut snapshots: Vec<String> = entries.iter()
+    let snapshot_entries: Vec<&tools::SubvolEntry> = entries.iter()
         .filter(|e| !protected.iter().any(|p| p.as_str() == e.path))
-        .map(|e| e.path.clone())
         .collect();
-    snapshots.sort();
+
+    let mut snapshots = Vec::new();
+    tools::with_toplevel(|toplevel| {
+        for entry in &snapshot_entries {
+            let path = format!("{toplevel}/{}", entry.path);
+            let created = tools::btrfs_subvol_creation_time(&path)
+                .unwrap_or_else(|_| "unknown".to_string());
+            snapshots.push(SnapshotInfo {
+                id: entry.id,
+                name: entry.path.clone(),
+                created,
+            });
+        }
+        Ok(())
+    })?;
+
+    snapshots.sort_by_key(|s| s.id);
     Ok(snapshots)
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -2,7 +2,8 @@
 //! calls create before every transaction. Retention evicts the oldest
 //! automatic snapshots when the count exceeds MAX_SNAPSHOTS. List and
 //! delete delegate to btrfs-progs; delete adds an fstab guard that
-//! btrfs-progs lacks.
+//! btrfs-progs lacks. rename_legacy_snapshot is a one-shot migration
+//! for systems upgraded from the fixed-name era.
 
 use std::fs;
 use std::path::Path;
@@ -236,6 +237,54 @@ pub fn delete(name: &str) -> Result<u64, String> {
         .map(|_| id)
 }
 
+/// Transforms btrfs-show creation time "YYYY-MM-DD HH:MM:SS" to the
+/// auto-name format "YYYY-MM-DD_HH-MM-SS".
+fn format_legacy_timestamp(btrfs_show: &str) -> String {
+    match btrfs_show.split_once(' ') {
+        Some((date, time)) => format!("{date}_{}", time.replace(':', "-")),
+        None => btrfs_show.to_string(),
+    }
+}
+
+/// One-shot migration for systems upgraded from the fixed-name era:
+/// renames `root.pre-update` to its creation timestamp so it joins the
+/// rolling history and participates in retention. Idempotent no-op if
+/// the legacy subvolume is absent. Errors are printed but do not
+/// propagate (called from %posttrans).
+pub fn rename_legacy_snapshot() {
+    let root_fstype = match tools::run_stdout("findmnt", &["-n", "-o", "FSTYPE", "/"]) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    if root_fstype != "btrfs" {
+        return;
+    }
+
+    let result = tools::with_toplevel(|toplevel| -> Result<Option<(String, u64)>, String> {
+        let legacy_path = format!("{toplevel}/root.pre-update");
+        if !Path::new(&legacy_path).exists() {
+            return Ok(None);
+        }
+        let creation = tools::btrfs_subvol_creation_time(&legacy_path)?;
+        let new_name = format_legacy_timestamp(&creation);
+        let new_path = format!("{toplevel}/{new_name}");
+        std::fs::rename(&legacy_path, &new_path)
+            .map_err(|e| format!("rename root.pre-update -> {new_name}: {e}"))?;
+        let id = tools::btrfs_subvol_id_by_name("/", &tools::SubvolName::new(new_name.clone()))?;
+        Ok(Some((new_name, id)))
+    });
+
+    match result {
+        Ok(Some((name, id))) => {
+            println!("atomic-rollback: migrated legacy snapshot 'root.pre-update' to '{name}' (ID {id})");
+        }
+        Ok(None) => {}
+        Err(e) => {
+            eprintln!("atomic-rollback: rename-legacy-snapshot: {e}");
+        }
+    }
+}
+
 // System subvolumes from fstab. These must never be deleted.
 fn fstab_subvol_names() -> Result<Vec<tools::SubvolName>, String> {
     let content = fs::read_to_string("/etc/fstab")
@@ -316,6 +365,17 @@ UUID=abc /home btrfs subvol=home 0 0";
         assert_eq!(super::parse_max_snapshots("MAX_SNAPSHOTS=abc"), crate::consts::MAX_SNAPSHOTS);
         assert_eq!(super::parse_max_snapshots("OTHER_KEY=50"), crate::consts::MAX_SNAPSHOTS);
         assert_eq!(super::parse_max_snapshots("MAX_SNAPSHOTS=0"), 0);
+    }
+
+    #[test]
+    fn legacy_timestamp_format() {
+        assert_eq!(
+            super::format_legacy_timestamp("2026-04-11 23:19:26"),
+            "2026-04-11_23-19-26");
+        assert_eq!(
+            super::format_legacy_timestamp("1999-01-01 00:00:00"),
+            "1999-01-01_00-00-00");
+        assert!(super::is_auto_name(&super::format_legacy_timestamp("2026-04-11 23:19:26")));
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -107,8 +107,8 @@ fn generate_auto_name() -> String {
 
 /// Result of a snapshot operation.
 pub enum SnapshotResult {
-    Created(String),
-    Existed(String),
+    Created(String, u64),
+    Existed(String, u64),
     NotBtrfs,
 }
 
@@ -135,22 +135,26 @@ pub fn snapshot(name: Option<&str>) -> Result<SnapshotResult, String> {
         Err(_) => return Ok(SnapshotResult::NotBtrfs),
     };
 
-    let result = tools::with_toplevel(|toplevel| {
+    let (name, created) = tools::with_toplevel(|toplevel| {
         let snap_path = format!("{toplevel}/{name}");
         if Path::new(&snap_path).exists() {
-            return Ok(SnapshotResult::Existed(name.to_string()));
+            return Ok((name.to_string(), false));
         }
         tools::btrfs_subvol_snapshot(&format!("{toplevel}/{}", root_subvol.as_str()), &snap_path)?;
-        Ok(SnapshotResult::Created(name.to_string()))
+        Ok((name.to_string(), true))
     })?;
 
-    if is_auto {
-        if let SnapshotResult::Created(_) = &result {
-            retain_auto_snapshots();
-        }
+    let id = tools::btrfs_subvol_id_by_name("/", &tools::SubvolName::new(name.clone()))?;
+
+    if is_auto && created {
+        retain_auto_snapshots();
     }
 
-    Ok(result)
+    if created {
+        Ok(SnapshotResult::Created(name, id))
+    } else {
+        Ok(SnapshotResult::Existed(name, id))
+    }
 }
 
 /// Returns top-level subvolume names, excluding fstab system subvolumes.
@@ -167,7 +171,7 @@ pub fn list() -> Result<Vec<String>, String> {
 
 /// Refuses subvolumes referenced by fstab (system subvolumes).
 /// Mounted and default subvolume protection from kernel and btrfs-progs.
-pub fn delete(name: &str) -> Result<(), String> {
+pub fn delete(name: &str) -> Result<u64, String> {
     let protected = fstab_subvol_names()?;
     if protected.contains(&tools::SubvolName::new(name.to_string())) {
         return Err(format!(
@@ -177,7 +181,7 @@ pub fn delete(name: &str) -> Result<(), String> {
 
     let id = tools::btrfs_subvol_id_by_name("/", &tools::SubvolName::new(name.to_string()))?;
     tools::run_stdout("btrfs", &["subvolume", "delete", "--subvolid", &id.to_string(), "/"])
-        .map(|_| ())
+        .map(|_| id)
 }
 
 // System subvolumes from fstab. These must never be deleted.

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -303,6 +303,22 @@ pub fn btrfs_subvol_snapshot(src: &str, dst: &str) -> Result<(), String> {
     run_stdout("btrfs", &["subvolume", "snapshot", src, dst]).map(|_| ())
 }
 
+/// Returns the creation time of a subvolume as a local-time string (%Y-%m-%d %H:%M:%S).
+/// The path must be the full path to the subvolume (e.g., via a toplevel mount).
+pub fn btrfs_subvol_creation_time(path: &str) -> Result<String, String> {
+    let out = run_stdout("btrfs", &["subvolume", "show", path])?;
+    for line in out.lines() {
+        let line = line.trim();
+        if let Some(raw) = line.strip_prefix("Creation time:") {
+            let raw = raw.trim();
+            // Drop the timezone suffix (e.g., " -0700") to get local-time datetime
+            let datetime = raw.rsplit_once(' ').map(|(dt, _tz)| dt).unwrap_or(raw);
+            return Ok(datetime.to_string());
+        }
+    }
+    Err(format!("no creation time found in btrfs subvolume show output for {path}"))
+}
+
 /// Looks up a subvolume's ID by name.
 pub fn btrfs_subvol_id_by_name(mount_point: &str, name: &SubvolName) -> Result<u64, String> {
     let entries = btrfs_subvol_list(mount_point)?;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -298,8 +298,7 @@ pub fn btrfs_subvol_set_default(id: u64, mount_point: &str) -> Result<(), String
 }
 
 /// Creates a btrfs snapshot of src at dst.
-/// Captures stdout because btrfs prints to stdout, which conflicts
-/// with the libdnf5 actions plugin's pipe when called from the dnf hook.
+/// Captures stdout to prevent btrfs output from interfering with the caller.
 pub fn btrfs_subvol_snapshot(src: &str, dst: &str) -> Result<(), String> {
     run_stdout("btrfs", &["subvolume", "snapshot", src, dst]).map(|_| ())
 }


### PR DESCRIPTION
Stacked on #21. GitHub will auto-retarget to main when #21 merges.

## Summary
- `check` and `rollback` now show which directories are protected (separate btrfs subvolumes, labeled SAFE) and which are inside root and will revert on rollback (labeled RISK).
- Derived from fstab `subvol=` entries and `is_mountpoint` checks on top-level directories.

## Test plan
- [x] VM (Fedora 43 btrfs): `check` produces "Boot chain is valid" + Rollback scope section with SAFE listing `/home` and `/var`, RISK listing non-empty root-internal directories
- [x] `rollback` call site present at src/rollback.rs:44, calls the same `print_rollback_scope` function verified via `check` (transit-verified: same function, same fstab input)
- [x] 23/23 unit tests pass