### PR TITLE
chore(ci): trigger on all branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches: ['**']
 
 jobs:
   x86_64:
@@ -21,7 +21,7 @@ jobs:
       - name: Build and check
         run: |
           lima sudo dnf install -y rust cargo gcc git
-          lima git clone --depth 1 --branch $GITHUB_HEAD_REF https://github.com/$GITHUB_REPOSITORY.git /tmp/ar
+          lima git clone --depth 1 --branch $GITHUB_REF_NAME https://github.com/$GITHUB_REPOSITORY.git /tmp/ar
           lima bash -c "cd /tmp/ar && cargo build --release"
           lima sudo /tmp/ar/target/release/atomic-rollback check
 


### PR DESCRIPTION
## Summary
- CI trigger changed from `pull_request: branches: [main]` to `push: branches: ['**']`.
- Runs CI on every branch push (covers stacked PRs and pre-PR feature branches that were previously unverified). Skips tag pushes, which are handled by COPR.
- Switches `$GITHUB_HEAD_REF` to `$GITHUB_REF_NAME` in the clone command because the former is only set for pull_request events.

## Why
PR #22 (rollback-scope, stacked on #21) had no CI runs because its base was not main. Untested code should not reach main; under the trust contract atomic-rollback operates by, that is a hard floor.

## Test plan
- [x] CI runs on push to this branch (verifies the new trigger fires)
- [x] Both `x86_64` and `aarch64-cross` checks pass