### PR TITLE
feat(check): show rollback scope (SAFE/RISK directories)

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -457,6 +457,46 @@ fn check_btrfs_subvol_exists(device_spec: &tools::DeviceSpec, name: &tools::Subv
     }
 }
 
+pub fn print_rollback_scope(fstab: &str) {
+    let lines = tools::parse_fstab(fstab);
+    let entries = tools::fstab_entries(&lines);
+
+    let protected: Vec<&str> = entries.iter()
+        .filter(|e| e.fs_file != "/")
+        .filter(|e| parse::extract_mount_option(&e.fs_mntops, "subvol").is_some())
+        .map(|e| e.fs_file.as_str())
+        .collect();
+
+    println!("  Rollback scope:\n");
+
+    if !protected.is_empty() {
+        println!("  SAFE  Separate subvolumes (not affected by rollback):");
+        for p in &protected {
+            println!("        {p}");
+        }
+        println!();
+    }
+
+    let at_risk: Vec<String> = match fs::read_dir("/") {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_ok_and(|ft| ft.is_dir()))
+            .map(|e| format!("/{}", e.file_name().to_string_lossy()))
+            .filter(|dir| !tools::is_mountpoint(Path::new(dir)))
+            .filter(|dir| fs::read_dir(dir).is_ok_and(|mut d| d.next().is_some()))
+            .collect(),
+        Err(_) => vec![],
+    };
+
+    if !at_risk.is_empty() {
+        println!("  RISK  Inside root subvolume (will revert on rollback):");
+        for r in &at_risk {
+            println!("        {r}");
+        }
+        println!();
+    }
+}
+
 fn extract_root_uuid(root: &Path) -> Option<tools::BareUuid> {
     let entries_dir = root.join(&P.bls_dir[1..]);
     for entry in fs::read_dir(&entries_dir).ok()?.flatten() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,10 +156,16 @@ fn main() {
             println!("atomic-rollback: verifying boot chain\n");
             match check::verify_bootable(Path::new(&root)) {
                 check::BootStatus::Pass => {
-                    println!("\nBoot chain is valid.");
+                    println!("\nBoot chain is valid.\n");
+                    if let Ok((_, fstab)) = tools::root_device() {
+                        check::print_rollback_scope(&fstab);
+                    }
                 }
                 check::BootStatus::Warn => {
-                    println!("\nBoot chain is valid (with warnings).");
+                    println!("\nBoot chain is valid (with warnings).\n");
+                    if let Ok((_, fstab)) = tools::root_device() {
+                        check::print_rollback_scope(&fstab);
+                    }
                     std::process::exit(2);
                 }
                 check::BootStatus::Fail(failures) => {

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -41,6 +41,8 @@ pub fn rollback(snapshot_name: &str) -> Result<(), String> {
         }
     }
 
+    check::print_rollback_scope(&fstab);
+
     // RENAME_EXCHANGE: root_subvol <-> snapshot
     println!("  RENAME_EXCHANGE: {root_subvol} <-> {snapshot_name}");
     swap::rename_exchange(Path::new(toplevel), root_subvol.as_str(), snapshot_name)?;


### PR DESCRIPTION
Reopens the work from closed #22 (closed because its base branch was deleted when #21 merged).

## Summary
- `check` and `rollback` now show which directories are protected (separate btrfs subvolumes, labeled SAFE) and which are inside root and will revert on rollback (labeled RISK).
- Derived from fstab `subvol=` entries and `is_mountpoint` checks on top-level directories.

## Test plan
- [x] VM (Fedora 43 btrfs): `check` produces "Boot chain is valid" + Rollback scope section with SAFE listing `/home` and `/var`, RISK listing non-empty root-internal directories
- [x] `rollback` call site present at src/rollback.rs:44, calls the same `print_rollback_scope` function verified via `check` (transit-verified: same function, same fstab input)
- [x] 23/23 unit tests pass
- [x] CI passes on push