### PR TITLE
ci: add cargo test job on ubuntu + macos matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: ['**']
 
 jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo test --release
+
   x86_64:
     runs-on: ubuntu-24.04
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Adds a `tests` job to CI that runs `cargo test --release` on a matrix of `[ubuntu-latest, macos-latest]`.
- Closes a real gap: the 23 unit tests had no CI gate. Local `cargo test` passes were the only signal; a regression could merge if the maintainer forgot to run tests before pushing.

## Why this matrix shape
Tests have a dependency surface — the set of things whose change could change the test's output. Tests should run at the minimum specificity that contains their dependency surface. For our 23 tests (parser tests, format conversion, name validation, no fs ops, no syscalls): dependency surface is pure Rust + libc-or-stdlib. They attach at the ROOT of the platform graph.

ROOT is bounded by what production code compiles for. Our code uses Unix APIs (`std::os::unix::fs::symlink`, `libc::localtime_r`) — compiles on Linux + macOS, not Windows. So ROOT = Unix platforms, and the matrix is `[ubuntu-latest, macos-latest]`.

Verified empirically that tests pass on macOS (Darwin 25.3.0, rustc 1.93.1, all 23 tests green) before adopting this design.

## Why not also Fedora VM
The existing `x86_64` lima Fedora VM job runs `atomic-rollback check` which DOES have Fedora-specific dependencies (specific paths, btrfs tooling, BLS layout). That's a deeper node in the dependency graph and stays where it is. Running unit tests inside the Fedora VM would be over-testing — pure-logic tests don't need a Fedora environment to verify their correctness.

## Test plan
- [x] Tests verified passing locally on macOS (Darwin 25.3.0, rustc 1.93.1, 23/23)
- [x] Workflow YAML diff is the minimum addition to existing file (existing jobs unchanged)
- [x] CI `tests (ubuntu-latest)` job passes on this PR (16s)
- [x] CI `tests (macos-latest)` job passes on this PR (27s)
- [x] Existing `x86_64` (2m15s) and `aarch64-cross` (35s) jobs still pass on this PR (no regression)