### PR TITLE
chore: move developer-local ignores to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-docs/plans/


### PR DESCRIPTION
Move developer-local ignore patterns to the global gitignore where they belong.